### PR TITLE
docs: add type="button" to buttons inside a form

### DIFF
--- a/apps/pink/src/pages/elements/input-field.mdx
+++ b/apps/pink/src/pages/elements/input-field.mdx
@@ -50,7 +50,11 @@ There are a few different types of input field that the user can interact with:
         <label class="label">Label</label>
         <div class="input-text-wrapper">
           <input type="password" class="input-text" placeholder="Placeholder" />
-          <button class="show-password-button" aria-label="show password">
+          <button 
+            class="show-password-button" 
+            aria-label="show password" 
+            type="button"
+          >
             <span class="icon-eye" aria-hidden="true"></span>
           </button>
         </div>
@@ -63,10 +67,15 @@ There are a few different types of input field that the user can interact with:
             <button
               class="options-list-button"
               aria-label="show password / hide password"
+              type="button"
             >
               <span class="icon-eye" aria-hidden="true"></span>
             </button>
-            <button class="options-list-button" aria-label="copy text">
+            <button 
+              class="options-list-button" 
+              aria-label="copy text" 
+              type="button"
+            >
               <span class="icon-duplicate" aria-hidden="true"></span>
             </button>
           </div>
@@ -109,6 +118,7 @@ There are a few different types of input field that the user can interact with:
                   <button
                     class="input-tag-delete-button"
                     aria-label="delete all:role tag"
+                    type="button"
                   >
                     <span class="icon-x" aria-hidden="true"></span>
                   </button>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Adds a `type="button"` to all the buttons inside a form as a part of an input field.

## Test Plan

Clicking a button inside any of the showcased input fields should not refresh the whole page anymore.

## Related PRs and Issues
#45 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
yup