### PR TITLE
doc: handle input right padding when icon present

### DIFF
--- a/apps/pink/src/pages/elements/input-field.mdx
+++ b/apps/pink/src/pages/elements/input-field.mdx
@@ -29,7 +29,7 @@ There are a few different types of input field that the user can interact with:
 | `text`     | Search | Used to input one or more terms to conduct a search. |
 
 <Preview center>
-  <div class="input-text-wrapper is-with-end-button u-width-full-line u-max-width-500">
+  <div class="input-text-wrapper is-with-end-button u-width-full-line u-max-width-500" style="--amount-of-buttons:1">
     <input type="search" placeholder="Search" />
     <div class="icon-search" aria-hidden="true"></div>
     <button class="button is-text is-only-icon" aria-label="Clear search" style="--button-size:1.5rem;">
@@ -48,7 +48,7 @@ There are a few different types of input field that the user can interact with:
     <ul class="form-list">
       <li class="form-item">
         <label class="label">Label</label>
-        <div class="input-text-wrapper">
+        <div class="input-text-wrapper" style="--amount-of-buttons:1">
           <input type="password" class="input-text" placeholder="Placeholder" />
           <button class="show-password-button" aria-label="show password">
             <span class="icon-eye" aria-hidden="true"></span>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Adds padding to input fields that have an icon on the right side, using the `--amount-of-buttons` property.

## Test Plan
A long input value should not overlap the icon on the right side anymore.

#### Before:
<img width="409" src="https://user-images.githubusercontent.com/46557266/216162715-08d90651-0a00-4cc0-b039-a0802d1a0788.png">


#### After:
<img width="408" src="https://user-images.githubusercontent.com/46557266/216162603-0c47f48f-2d7a-46b4-b00a-22c028dc7848.png">


## Related PRs and Issues
#47 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yup