### PR TITLE
show star icon besides github stars in header

### DIFF
--- a/apps/pink/src/components/layout/Header.astro
+++ b/apps/pink/src/components/layout/Header.astro
@@ -75,8 +75,7 @@ async function getRepoStars() {
           class="button is-text"
         >
           <span class="icon-github" aria-hidden="true"></span>
-          <span class="text">GitHub</span>
-          <span class="tag u-text-center">{getRepoStars()}</span>
+          <span class="tag u-text-center">{getRepoStars()} <span class="icon-star"></span></span>
         </a>
       </li>
       <li class="buttons-list-item u-padding-inline-0">


### PR DESCRIPTION
## What does this PR do?

Updates the header UI to :

* removes Github label .
* Add star icon after github stars number . 

## Test Plan

No test provided yet .

## Related PRs and Issues

Fixes #70 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes 