### PR TITLE
[Bug Fixed] Added Transform Scale up to article cards while hovering

### DIFF
--- a/apps/pink/src/pages/index.astro
+++ b/apps/pink/src/pages/index.astro
@@ -995,4 +995,12 @@ const articles: Article[] = [
   .SG-box-shadow-32 {
     box-shadow: 0 pxToRem(16) pxToRem(32) rgba(55, 59, 77, 0.02);
   }
+
+  //articles card styling
+  .articles-item {
+    transition: transform 0.3s ease-in-out;
+  }
+  .articles-item:hover {
+    transform: scale(1.02);
+  }
 </style>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)
Check Out this video for the output of the feature
https://www.awesomescreenshot.com/video/19671375?key=9f49c865f32354211893b8283c875f5e

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
I simply added two lines of css code to make these changes
` .articles-item {
    transition: transform 0.3s ease-in-out;
  }
  .articles-item:hover {
    transform: scale(1.02);
  }`

## Related PRs and Issues
#99 Fixed
(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
(Write your answer here.)
YES