### PR TITLE
Automate Copyright Year

### DIFF
--- a/apps/pink/src/layouts/Layout.astro
+++ b/apps/pink/src/layouts/Layout.astro
@@ -158,7 +158,7 @@ const titleFallback = "Pink Design - Appwrite's Design System";
     <div class="main-footer-end">
       <ul class="inline-links is-no-padding-first-and-last u-x-small">
         <li class="inline-links-item">
-          <span class="text">ⓒ 2023 Appwrite. All rights reserved.</span>
+          <span class="text">ⓒ {new Date().getFullYear()} Appwrite. All rights reserved.</span>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## What does this PR do?

Uses `new Date().getFullYear()` so there's no need to manually update the copyright year.

## Test Plan

Manual.


## Related PRs and Issues

[#165.](https://github.com/appwrite/pink/issues/165)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.