### PR TITLE
Add maxwidth with default

### DIFF
--- a/v2/pink-sb/src/lib/Tooltip.svelte
+++ b/v2/pink-sb/src/lib/Tooltip.svelte
@@ -7,6 +7,7 @@
     export let padding: 'none' | 'm' = 'm';
     export let offsetAmount: number = 6;
     export let disabled = false;
+    export let maxWidth = '11.25rem';
     let show = false;
     const id = 'tooltip-' + Math.random().toString(16).slice(2);
     let referenceElement: HTMLDivElement;
@@ -56,6 +57,7 @@
     class:padding-none={padding === 'none'}
     class:padding-m={padding === 'm'}
     role="tooltip"
+    style:max-inline-size={maxWidth}
     data-state={!show ? 'closed' : 'open'}
 >
     <slot showing={show} {update} name="tooltip" />


### PR DESCRIPTION
## What does this PR do?
Add a max width to the tooltip content
<img width="219" alt="image" src="https://github.com/user-attachments/assets/421b4ce1-c3a9-4dcd-9e63-2629a6580da5" />


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅