### PR TITLE
Fix icons safari

### DIFF
--- a/v2/pink-sb/src/lib/Icon.svelte
+++ b/v2/pink-sb/src/lib/Icon.svelte
@@ -28,6 +28,10 @@
         position: relative;
         fill: var(--icon-fill);
 
+        :global(svg) {
+            width: var(--p-icon-size);
+        }
+
         &.xs {
             --p-icon-size: var(--icon-size-xs);
         }


### PR DESCRIPTION
## What does this PR do?

The lack of dimension on the svg tag makes Safari not showing the icons. This fixes that.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅