### PR TITLE
Since the SVG's are using current-color, the actual color needs to be…

### DIFF
--- a/v2/pink-sb/src/lib/Icon.svelte
+++ b/v2/pink-sb/src/lib/Icon.svelte
@@ -3,7 +3,7 @@
 
     export let icon: ComponentType;
     export let size: 'xs' | 's' | 'm' | 'l' = 'm';
-    export let color: string = '--color-fgcolor-neutral-tertiary';
+    export let color: string = 'current-color';
 </script>
 
 <i
@@ -27,6 +27,7 @@
         height: var(--p-icon-size);
         position: relative;
         fill: var(--icon-fill);
+        color: var(--icon-fill);
 
         :global(svg) {
             width: var(--p-icon-size);


### PR DESCRIPTION

## What does this PR do?
Since the SVG's are using current-color, the actual color needs to be set. Not just the fill. Because that one gets overwritten. Adjusted the default, so not all icons become the dark color when this is merged.

<img width="172" alt="image" src="https://github.com/user-attachments/assets/2ca8394e-f78e-4615-a556-5b968bd5fd94" />


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅