### PR TITLE
Add prop to allow keys with more than 1 char

### DIFF
--- a/v2/pink-sb/src/lib/Keyboard.svelte
+++ b/v2/pink-sb/src/lib/Keyboard.svelte
@@ -11,9 +11,10 @@
 
 <script lang="ts">
     export let key: string;
+    export let autoWidth: boolean = false;
 </script>
 
-<kbd>{key}</kbd>
+<kbd class:autoWidth>{key}</kbd>
 
 <style lang="scss">
     kbd {
@@ -29,5 +30,9 @@
 
         border-radius: 6px;
         background: var(--color-overlay-on-neutral);
+    }
+    .autoWidth {
+        width: fit-content;
+        padding-inline: var(--space-3);
     }
 </style>

--- a/v2/pink-sb/src/stories/Keyboard.stories.svelte
+++ b/v2/pink-sb/src/stories/Keyboard.stories.svelte
@@ -25,6 +25,7 @@
         <Keyboard key={SpecialCharacter.Right} />
         <Keyboard key={SpecialCharacter.Down} />
         <Keyboard key={SpecialCharacter.Left} />
+        <Keyboard key={'Enter'} autoWidth={true} />
     </Stack>
 </Template>
 


### PR DESCRIPTION
## What does this PR do?

Allow for keys with more than 1 character:
<img width="91" alt="image" src="https://github.com/user-attachments/assets/69293dfe-f286-4460-a6dc-88fbc01c1656" />


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅