### PR TITLE
Prevent word wrapping when badge or trailing icon is (not) present

### DIFF
--- a/v2/pink-sb/src/lib/action-menu/Anchor.svelte
+++ b/v2/pink-sb/src/lib/action-menu/Anchor.svelte
@@ -43,14 +43,22 @@
                 <slot />
             </span>
         </Stack>
-        <Stack direction="row" gap="s" alignItems="center" justifyContent="flex-end">
-            {#if badge}
-                <Badge variant="secondary" content={badge} />
-            {/if}
-            {#if trailingIcon}
-                <Icon size="s" icon={trailingIcon} />
-            {/if}
-        </Stack>
+        {#if badge || trailingIcon}
+            <Stack
+                direction="row"
+                gap="s"
+                alignItems="center"
+                justifyContent="flex-end"
+                inline={true}
+            >
+                {#if badge}
+                    <Badge variant="secondary" content={badge} />
+                {/if}
+                {#if trailingIcon}
+                    <Icon size="s" icon={trailingIcon} />
+                {/if}
+            </Stack>
+        {/if}
     </Stack>
 </a>
 

--- a/v2/pink-sb/src/lib/action-menu/Button.svelte
+++ b/v2/pink-sb/src/lib/action-menu/Button.svelte
@@ -37,14 +37,22 @@
                 <slot />
             </span>
         </Stack>
-        <Stack direction="row" gap="s" alignItems="center" justifyContent="flex-end">
-            {#if badge}
-                <Badge variant="secondary" content={badge} />
-            {/if}
-            {#if trailingIcon}
-                <Icon size="s" icon={trailingIcon} />
-            {/if}
-        </Stack>
+        {#if badge || trailingIcon}
+            <Stack
+                direction="row"
+                gap="s"
+                alignItems="center"
+                justifyContent="flex-end"
+                inline={true}
+            >
+                {#if badge}
+                    <Badge variant="secondary" content={badge} />
+                {/if}
+                {#if trailingIcon}
+                    <Icon size="s" icon={trailingIcon} />
+                {/if}
+            </Stack>
+        {/if}
     </Stack>
 </button>
 

--- a/v2/pink-sb/src/stories/ActionMenu.stories.svelte
+++ b/v2/pink-sb/src/stories/ActionMenu.stories.svelte
@@ -40,7 +40,9 @@
 
 <Story name="Anchor">
     <ActionMenu.Root>
-        <ActionMenu.Item.Anchor href="#" leadingIcon={IconInfo}>Default</ActionMenu.Item.Anchor>
+        <ActionMenu.Item.Anchor href="#" leadingIcon={IconInfo} trailingIcon={IconInfo}
+            >Default with a very long text</ActionMenu.Item.Anchor
+        >
         <ActionMenu.Item.Anchor href="#" leadingIcon={IconInfo} disabled>
             Default
         </ActionMenu.Item.Anchor>

--- a/v2/pink-sb/src/stories/ActionMenu.stories.svelte
+++ b/v2/pink-sb/src/stories/ActionMenu.stories.svelte
@@ -25,6 +25,13 @@
         <ActionMenu.Item.Button
             leadingIcon={IconInfo}
             trailingIcon={IconChevronDoubleRight}
+            badge="1"
+        >
+            Default with a very long text
+        </ActionMenu.Item.Button>
+        <ActionMenu.Item.Button
+            leadingIcon={IconInfo}
+            trailingIcon={IconChevronDoubleRight}
             disabled
         >
             Default


### PR DESCRIPTION
## What does this PR do?
ActionMenu Anchor and Button don't take up full available space when no icon or badge is present. And if the icon or badge is present, they take up the width 50/50 with the text (making the text wrap in most cases). This PR fixes that.

ActionMenu.Item.Button before:
<img width="379" alt="image" src="https://github.com/user-attachments/assets/45cd4d91-3add-4b21-99ab-cba2c890e0a5" />

ActionMenu.Item.Button after:
<img width="376" alt="image" src="https://github.com/user-attachments/assets/1b4d20d2-40c3-4e5c-871e-4666c094f94b" />

ActionMenu.Item.Anchor before:
<img width="377" alt="image" src="https://github.com/user-attachments/assets/0f8ac6da-a476-4827-9a62-ad8229df8a55" />


ActionMenu.Item.Anchor after:
<img width="377" alt="image" src="https://github.com/user-attachments/assets/3d3ea4f0-1ae9-41d7-9893-42ccf40e3e5e" />

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
Yes