### PR TITLE
ActionMenu uses 4px padding, so added a xxxs option

### DIFF
--- a/v2/pink-sb/src/lib/card/Base.svelte
+++ b/v2/pink-sb/src/lib/card/Base.svelte
@@ -2,7 +2,7 @@
     export type BaseCardProps = Partial<{
         variant: 'primary' | 'secondary';
         radius: 's' | 'm' | 'l';
-        padding: 'none' | 'xxs' | 'xs' | 's' | 'm' | 'l';
+        padding: 'none' | 'xxxs' | 'xxs' | 'xs' | 's' | 'm' | 'l';
         border: 'solid' | 'dashed';
         shadow?: boolean;
     }>;
@@ -27,6 +27,7 @@
     class:radius-m={radius === 'm'}
     class:radius-l={radius === 'l'}
     class:padding-none={padding === 'none'}
+    class:padding-xxxs={padding === 'xxxs'}
     class:padding-xxs={padding === 'xxs'}
     class:padding-xs={padding === 'xs'}
     class:padding-s={padding === 's'}

--- a/v2/pink-sb/src/lib/card/_card.scss
+++ b/v2/pink-sb/src/lib/card/_card.scss
@@ -33,6 +33,9 @@
         &-none {
             padding: 0;
         }
+        &xxxs {
+            padding: var(--space-2);
+        }
         &xxs {
             padding: var(--space-4);
         }


### PR DESCRIPTION
## What does this PR do?

Added smaller padding option to support ActionMenu

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅