### PR TITLE
Fix: responsiveness on dialog

### DIFF
--- a/v2/pink-sb/src/lib/Dialog.svelte
+++ b/v2/pink-sb/src/lib/Dialog.svelte
@@ -76,11 +76,15 @@
             justify-content: center;
             align-items: center;
             overflow: hidden;
-            width: 440px;
             border-radius: var(--border-radius-l);
             border: var(--border-width-s) solid var(--color-border-neutral);
             background: var(--color-bgcolor-neutral-primary);
             color: var(--color-fgcolor-neutral-primary);
+
+            @media (min-width: 460px) {
+                width: 440px;
+                max-width: none;
+            }
 
             /* box-shadow/neutral/XL */
             box-shadow:


### PR DESCRIPTION
## What does this PR do?
Fix the responsiveness of the Dialog component

Before:
<img width="343" alt="image" src="https://github.com/user-attachments/assets/33d54ba4-c7fc-4c5b-9b10-a6da7def874e" />


After:
<img width="343" alt="image" src="https://github.com/user-attachments/assets/fcbefcff-d8ec-44d4-b587-06161d7c4ab7" />

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅