### PR TITLE
Feat: add option for custom badge text

### DIFF
--- a/v2/pink-sb/src/lib/step/StepItem.svelte
+++ b/v2/pink-sb/src/lib/step/StepItem.svelte
@@ -6,6 +6,7 @@
     export let noLine: boolean = false;
     export let shortLine: boolean = false;
     export let hideBadge: boolean = false;
+    export let badgeText: undefined | string = undefined;
     export let hideActiveTopLine: boolean = false;
     export let hideActiveBottomLine: boolean = false;
 </script>
@@ -42,7 +43,13 @@
                 <div class="badge" class:active-badge={state === 'current'}>
                     <Badge
                         variant="secondary"
-                        content={state === 'next' ? 'Next' : state === 'current' ? 'Now' : `Done`}
+                        content={badgeText !== undefined
+                            ? badgeText
+                            : state === 'next'
+                              ? 'Next'
+                              : state === 'current'
+                                ? 'Now'
+                                : `Done`}
                     >
                         <div slot="start">
                             {#if state === 'previous'}<img src={Done} alt="" />{/if}

--- a/v2/pink-sb/src/stories/Step.stories.svelte
+++ b/v2/pink-sb/src/stories/Step.stories.svelte
@@ -49,6 +49,17 @@
                 </p>
             </div></Step.Item
         >
+        <Step.Item state="next" badgeText="Custom"
+            ><div>
+                <p>
+                    Nullam at quam pharetra, dignissim erat non, pharetra eros. Ut vitae magna
+                    commodo, pretium risus at, elementum enim. Cras erat lectus, aliquet vel sem
+                    eget, tristique aliquam justo. Praesent et leo aliquam, bibendum turpis eget,
+                    egestas enim. Maecenas ac interdum ex, ac aliquet magna. Vestibulum ante ipsum
+                    primis in faucibus orci luctus et ultrices posuere cubilia curae
+                </p>
+            </div></Step.Item
+        >
         <Step.Item state="next" noLine={true}
             ><div>
                 <p>


### PR DESCRIPTION
## What does this PR do?
Add option for custom badge text in step component:
<img width="159" alt="image" src="https://github.com/user-attachments/assets/0e40bf13-589f-49bd-aaa2-d984644644ab" />

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅