### PR TITLE
Fix: disable transitions when swapping viewport to mobile

### DIFF
--- a/v2/pink-sb/src/lib/sidebar/Base.svelte
+++ b/v2/pink-sb/src/lib/sidebar/Base.svelte
@@ -9,18 +9,20 @@
     export let state: $$Props['state'] = 'open';
     export let resizable: $$Props['resizable'] = true;
 
-    let noTransition = true;
+    let noTransition = false;
     let prevWidth = window.innerWidth;
 
     function monitorViewport() {
         const width = window.innerWidth;
 
-        // if (prevWidth >= 1024 && width < 1024) {
-        //     noTransition = true;
-        //     tick().then(() => {
-        //         noTransition = false;
-        //     });
-        // }
+        if (prevWidth >= 1024 && width < 1024) {
+            noTransition = true;
+            console.log('noTransition', noTransition);
+            setTimeout(() => {
+                console.log('noTransition back to false');
+                noTransition = false;
+            }, 200);
+        }
 
         prevWidth = width;
     }

--- a/v2/pink-sb/src/lib/sidebar/Base.svelte
+++ b/v2/pink-sb/src/lib/sidebar/Base.svelte
@@ -2,14 +2,31 @@
     import { Badge, Icon } from '$lib/index.js';
     import { IconChevronLeft, IconChevronRight, IconMinus } from '@appwrite.io/pink-icons-svelte';
     import type { $$Props } from '$lib/sidebar/index.js';
-    import { createEventDispatcher } from 'svelte';
+    import { createEventDispatcher, tick } from 'svelte';
 
     const dispatch = createEventDispatcher();
 
     export let state: $$Props['state'] = 'open';
     export let resizable: $$Props['resizable'] = true;
+
+    let noTransition = false;
+    let prevWidth = window.innerWidth;
+
+    function monitorViewport() {
+        const width = window.innerWidth;
+
+        if (prevWidth >= 1024 && width < 1024) {
+            noTransition = true;
+            tick().then(() => {
+                noTransition = false;
+            });
+        }
+
+        prevWidth = width;
+    }
 </script>
 
+<svelte:window on:resize={monitorViewport} />
 {#if resizable}
     <button
         class="collapse"
@@ -41,6 +58,7 @@
     class:only-icons={state === 'icons'}
     class:open={state === 'open'}
     class:closed={state === 'closed'}
+    class:noTransition
     {...$$props}
 >
     <slot name="top"></slot>
@@ -73,7 +91,11 @@
         background: var(--bgcolor-neutral-primary, #fff);
         border-right: var(--border-width-s, 1px) solid var(--border-neutral, #ededf0);
 
-        transition: all 0.2s ease-in-out;
+        transition:
+            transform 0.2s ease-in-out,
+            opacity 0.2s ease-in-out,
+            width 0.2s ease-in-out,
+            filter 0.2s ease-in-out;
 
         @media (min-width: 1024px) {
             overflow: visible;
@@ -195,5 +217,9 @@
         to {
             opacity: 1;
         }
+    }
+
+    .noTransition {
+        transition: none !important;
     }
 </style>

--- a/v2/pink-sb/src/lib/sidebar/Base.svelte
+++ b/v2/pink-sb/src/lib/sidebar/Base.svelte
@@ -2,7 +2,7 @@
     import { Badge, Icon } from '$lib/index.js';
     import { IconChevronLeft, IconChevronRight, IconMinus } from '@appwrite.io/pink-icons-svelte';
     import type { $$Props } from '$lib/sidebar/index.js';
-    import { createEventDispatcher, tick } from 'svelte';
+    import { createEventDispatcher } from 'svelte';
 
     const dispatch = createEventDispatcher();
 
@@ -17,9 +17,7 @@
 
         if (prevWidth >= 1024 && width < 1024) {
             noTransition = true;
-            console.log('noTransition', noTransition);
             setTimeout(() => {
-                console.log('noTransition back to false');
                 noTransition = false;
             }, 200);
         }

--- a/v2/pink-sb/src/lib/sidebar/Base.svelte
+++ b/v2/pink-sb/src/lib/sidebar/Base.svelte
@@ -9,18 +9,18 @@
     export let state: $$Props['state'] = 'open';
     export let resizable: $$Props['resizable'] = true;
 
-    let noTransition = false;
+    let noTransition = true;
     let prevWidth = window.innerWidth;
 
     function monitorViewport() {
         const width = window.innerWidth;
 
-        if (prevWidth >= 1024 && width < 1024) {
-            noTransition = true;
-            tick().then(() => {
-                noTransition = false;
-            });
-        }
+        // if (prevWidth >= 1024 && width < 1024) {
+        //     noTransition = true;
+        //     tick().then(() => {
+        //         noTransition = false;
+        //     });
+        // }
 
         prevWidth = width;
     }


### PR DESCRIPTION
## What does this PR do?

Smooth out viewport transition and sidebar

Before:

https://github.com/user-attachments/assets/216577d6-4397-4ad2-b26c-14b480eb46ae



After:

https://github.com/user-attachments/assets/f62defdb-dbdf-4a85-ac2c-ebd587c65616




### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅