### PR TITLE
Width to `ActionMenu.Root`

### DIFF
--- a/v2/pink-sb/src/lib/action-menu/Root.svelte
+++ b/v2/pink-sb/src/lib/action-menu/Root.svelte
@@ -1,17 +1,21 @@
 <script lang="ts">
+    export let width: string | undefined = undefined;
     export let noPadding: undefined | boolean = false;
 </script>
 
-<div style:--action-menu-root-padding={noPadding ? 0 : 'var(--space-2)'}>
+<div
+        style:--action-menu-root-width={width ? width : '224px'}
+        style:--action-menu-root-padding={noPadding ? 0 : 'var(--space-2)'}
+>
     <slot />
 </div>
 
 <style lang="scss">
     div {
         display: flex;
+        overflow: hidden;
         flex-direction: column;
         padding: var(--action-menu-root-padding);
-        overflow: hidden;
-        min-width: 224px;
+        min-width: var(--action-menu-root-width);
     }
 </style>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Popover look odd if the width is too much compared to designs.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)