### PR TITLE
Fix for popover closing when used with a Select inside it

### DIFF
--- a/v2/pink-sb/src/lib/Popover.svelte
+++ b/v2/pink-sb/src/lib/Popover.svelte
@@ -24,7 +24,7 @@
 
     async function onBlur(event: MouseEvent & { currentTarget: EventTarget & Window }) {
         const target = event.target as Node;
-        if (show && !tooltipElement.contains(target) && target.parentElement !== null) {
+        if (show && !tooltipElement.contains(target) && document.contains(target)) {
             activeInstance.set(null);
         }
     }

--- a/v2/pink-sb/src/lib/Popover.svelte
+++ b/v2/pink-sb/src/lib/Popover.svelte
@@ -23,7 +23,8 @@
     }
 
     async function onBlur(event: MouseEvent & { currentTarget: EventTarget & Window }) {
-        if (show && !tooltipElement.contains(event.target as Node)) {
+        const target = event.target as Node;
+        if (show && !tooltipElement.contains(target) && target.parentElement !== null) {
             activeInstance.set(null);
         }
     }


### PR DESCRIPTION
## What does this PR do?
When the popover has an element in the tooltip that can disappear, e.g. when using a select, it closes the popover. This check ensures this doesn't happen. 

Before: 

https://github.com/user-attachments/assets/6e09d203-8540-43b3-8ada-2a8cbf4d2975

After:

https://github.com/user-attachments/assets/8c8bba7a-8c76-4f5a-be3a-64f509b396f0




### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅