### PR TITLE
Custom card image size

### DIFF
--- a/v2/pink-sb/src/lib/card/Selector.svelte
+++ b/v2/pink-sb/src/lib/card/Selector.svelte
@@ -39,6 +39,8 @@
     export let imageHeight: $$Props['imageHeight'] = 148;
     export let imageWidth: $$Props['imageWidth'] = undefined;
     export let disabled: $$Props['disabled'] = undefined;
+
+    const constrainedImageHeight = Math.min(imageHeight, 148);
 </script>
 
 <Card.Label {variant} {radius} {padding} selected={value === group} {disabled}>
@@ -50,8 +52,8 @@
                     alt={alt ?? title}
                     width={imageWidth}
                     radius={imageRadius}
-                    height={imageHeight}
-                    style={`height: ${imageHeight}px; width: ${imageWidth}px; pointer-events: none`}
+                    height={constrainedImageHeight}
+                    style={`height: ${constrainedImageHeight}px; width: ${imageWidth}px; pointer-events: none`}
                 />
             </div>
         {/if}

--- a/v2/pink-sb/src/lib/card/Selector.svelte
+++ b/v2/pink-sb/src/lib/card/Selector.svelte
@@ -42,14 +42,21 @@
 <Card.Label {variant} {radius} {padding} selected={value === group} {disabled}>
     <Layout.Stack gap="m">
         {#if src}
-            <Image
-                radius={imageRadius}
-                {src}
-                alt={alt ?? title}
-                height={imageSize}
-                width={imageSize}
-                style={`height: ${imageSize}px; width: ${imageSize}px; pointer-events: none`}
-            />
+            <div
+                style:height="148px"
+                style:width="148px"
+                style:alig-content="center"
+                style:justify-items="center"
+            >
+                <Image
+                    radius={imageRadius}
+                    {src}
+                    alt={alt ?? title}
+                    height={imageSize}
+                    width={imageSize}
+                    style={`height: ${imageSize}px; width: ${imageSize}px; pointer-events: none`}
+                />
+            </div>
         {/if}
         <Layout.Stack direction="row" gap="s">
             <!-- TODO: temporary fix -->

--- a/v2/pink-sb/src/lib/card/Selector.svelte
+++ b/v2/pink-sb/src/lib/card/Selector.svelte
@@ -44,7 +44,6 @@
         {#if src}
             <div
                 style:height="148px"
-                style:width="148px"
                 style:alig-content="center"
                 style:justify-items="center"
             >

--- a/v2/pink-sb/src/lib/card/Selector.svelte
+++ b/v2/pink-sb/src/lib/card/Selector.svelte
@@ -15,6 +15,7 @@
             title: string;
             info?: string | undefined;
             icon?: ComponentType;
+            imageSize?: number;
             imageRadius?: 'xxs' | 'xs' | 's' | 'm' | 'l';
             disabled?: boolean;
             src?: string;
@@ -34,6 +35,7 @@
     export let src: $$Props['src'] = undefined;
     export let alt: $$Props['alt'] = undefined;
     export let imageRadius: $$Props['imageRadius'] = 'xs';
+    export let imageSize: $$Props['imageSize'] = 148;
     export let disabled: $$Props['disabled'] = undefined;
 </script>
 
@@ -44,8 +46,8 @@
                 radius={imageRadius}
                 {src}
                 alt={alt ?? title}
-                height={148}
-                style="height: 148px; pointer-events: none"
+                height={imageSize}
+                style={`height: ${imageSize}px; pointer-events: none`}
             />
         {/if}
         <Layout.Stack direction="row" gap="s">

--- a/v2/pink-sb/src/lib/card/Selector.svelte
+++ b/v2/pink-sb/src/lib/card/Selector.svelte
@@ -15,7 +15,8 @@
             title: string;
             info?: string | undefined;
             icon?: ComponentType;
-            imageSize?: number;
+            imageHeight?: number;
+            imageWidth?: number;
             imageRadius?: 'xxs' | 'xs' | 's' | 'm' | 'l';
             disabled?: boolean;
             src?: string;
@@ -35,8 +36,8 @@
     export let src: $$Props['src'] = undefined;
     export let alt: $$Props['alt'] = undefined;
     export let imageRadius: $$Props['imageRadius'] = 'xs';
-    export let imageHeight: $$Props['imageSize'] = 148;
-    export let imageWidth: $$Props['imageSize'] = undefined;
+    export let imageHeight: $$Props['imageHeight'] = 148;
+    export let imageWidth: $$Props['imageWidth'] = undefined;
     export let disabled: $$Props['disabled'] = undefined;
 </script>
 

--- a/v2/pink-sb/src/lib/card/Selector.svelte
+++ b/v2/pink-sb/src/lib/card/Selector.svelte
@@ -44,7 +44,7 @@
 <Card.Label {variant} {radius} {padding} selected={value === group} {disabled}>
     <Layout.Stack gap="m">
         {#if src}
-            <div style:height="148px" style:alig-content="center" style:justify-items="center">
+            <div style:height="148px" style:align-content="center" style:justify-items="center">
                 <Image
                     {src}
                     alt={alt ?? title}

--- a/v2/pink-sb/src/lib/card/Selector.svelte
+++ b/v2/pink-sb/src/lib/card/Selector.svelte
@@ -35,25 +35,22 @@
     export let src: $$Props['src'] = undefined;
     export let alt: $$Props['alt'] = undefined;
     export let imageRadius: $$Props['imageRadius'] = 'xs';
-    export let imageSize: $$Props['imageSize'] = 148;
+    export let imageHeight: $$Props['imageSize'] = 148;
+    export let imageWidth: $$Props['imageSize'] = undefined;
     export let disabled: $$Props['disabled'] = undefined;
 </script>
 
 <Card.Label {variant} {radius} {padding} selected={value === group} {disabled}>
     <Layout.Stack gap="m">
         {#if src}
-            <div
-                style:height="148px"
-                style:alig-content="center"
-                style:justify-items="center"
-            >
+            <div style:height="148px" style:alig-content="center" style:justify-items="center">
                 <Image
-                    radius={imageRadius}
                     {src}
                     alt={alt ?? title}
-                    height={imageSize}
-                    width={imageSize}
-                    style={`height: ${imageSize}px; width: ${imageSize}px; pointer-events: none`}
+                    width={imageWidth}
+                    radius={imageRadius}
+                    height={imageHeight}
+                    style={`height: ${imageHeight}px; width: ${imageWidth}px; pointer-events: none`}
                 />
             </div>
         {/if}

--- a/v2/pink-sb/src/lib/card/Selector.svelte
+++ b/v2/pink-sb/src/lib/card/Selector.svelte
@@ -47,7 +47,8 @@
                 {src}
                 alt={alt ?? title}
                 height={imageSize}
-                style={`height: ${imageSize}px; pointer-events: none`}
+                width={imageSize}
+                style={`height: ${imageSize}px; width: ${imageSize}px; pointer-events: none`}
             />
         {/if}
         <Layout.Stack direction="row" gap="s">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Allows doing this without explicit custom css usage, when the preview might be a generic file type image -

<img width="983" alt="Screenshot 2025-04-29 at 3 06 49 PM" src="https://github.com/user-attachments/assets/dd53e312-b033-4046-a91d-857da149216e" />

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)