### PR TITLE
Use aspect-ratio to guarantee circular selected state

### DIFF
--- a/v2/pink-sb/src/lib/selector/Radio.svelte
+++ b/v2/pink-sb/src/lib/selector/Radio.svelte
@@ -78,9 +78,12 @@
                 content: '';
                 display: block;
                 position: absolute;
-                inset: 30%;
+                aspect-ratio: 1 /1;
+                width: calc(var(--p-radio-size) * 0.4);
+                left: calc(50% - (var(--p-radio-size) * 0.2));
+                top: calc(50% - (var(--p-radio-size) * 0.2));
                 background-color: var(--fgcolor-on-invert);
-                border-radius: var(--border-radius-circle);
+                border-radius: 100%;
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?
Before the selected circle within the input was centred and sized by the inset property, which gives it equal margin all round. However, when the input itself wouldn't be square, that would mean the circle would also not be square. 

Exaggerated example:
<img width="221" alt="image" src="https://github.com/user-attachments/assets/3d841e5a-aaf3-4f17-91e0-3440926efd11" />

By fixating the width and the aspect-ratio, the circle is now guaranteed to be a perfect circle, even when the input itself is strechted:
<img width="115" alt="image" src="https://github.com/user-attachments/assets/3cf378c1-31d3-44b6-9aa9-26e318393b5f" />
 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅