### PR TITLE
fix: tooltips showing race condition

### DIFF
--- a/v2/pink-sb/src/lib/Tooltip.svelte
+++ b/v2/pink-sb/src/lib/Tooltip.svelte
@@ -10,13 +10,14 @@
     export let maxWidth = '11.25rem';
 
     let show = false;
+    let showing = false;
     const id = 'tooltip-' + Math.random().toString(36).substring(2, 9);
     let referenceElement: HTMLSpanElement;
     let tooltipElement: HTMLDivElement;
 
     async function showTooltip() {
         await update();
-        show = !disabled;
+        showing = show = !disabled;
     }
 
     function hideTooltip() {
@@ -54,10 +55,11 @@
     on:mouseleave={hideTooltip}
     on:blur={hideTooltip}
 >
-    <slot showing={show} {update} />
+    <slot {showing} {update} />
 </span>
 <div
     {id}
+    on:transitionend={() => (showing = false)}
     bind:this={tooltipElement}
     aria-hidden={!show}
     class:padding-none={padding === 'none'}
@@ -66,7 +68,7 @@
     style:max-inline-size={maxWidth}
     data-state={!show ? 'closed' : 'open'}
 >
-    <slot showing={show} {update} name="tooltip" />
+    <slot {showing} {update} name="tooltip" />
 </div>
 
 <style lang="scss">

--- a/v2/pink-sb/src/stories/Tooltip.stories.svelte
+++ b/v2/pink-sb/src/stories/Tooltip.stories.svelte
@@ -35,6 +35,18 @@
 
 <Story name="Default" />
 <Story name="Hover" {play} />
+<Story name="Hide Tooltip content when closed">
+    <div class="container">
+        <Tooltip>
+            <Button on:click={() => (toggle = !toggle)}>Hover me</Button>
+            <p slot="tooltip" let:showing>
+                {#if showing}
+                    Long text that can do stuff.
+                {/if}
+            </p>
+        </Tooltip>
+    </div>
+</Story>
 
 <style>
     .container {


### PR DESCRIPTION
- Introduces a separate `showing` variable to distinguish between tooltip visibility and content rendering. 
- The tooltip content can now be conditionally rendered based on the `showing` state, which updates after CSS transitions complete.