### PR TITLE
Fix/textarea inner components

### DIFF
--- a/v2/pink-sb/src/lib/input/Textarea.svelte
+++ b/v2/pink-sb/src/lib/input/Textarea.svelte
@@ -69,7 +69,9 @@
     @use '../../scss/mixins/transitions';
 
     .input {
-        @include transitions.common;
+        transition:
+            all 0.15s ease-in-out,
+            height 0s;
 
         display: flex;
         flex-direction: column;

--- a/v2/pink-sb/src/lib/input/Textarea.svelte
+++ b/v2/pink-sb/src/lib/input/Textarea.svelte
@@ -4,6 +4,7 @@
     import type { HTMLTextareaAttributes } from 'svelte/elements';
     import type { States } from './types.js';
     import { autofocusInput } from './autofocus.js';
+    import { Layout } from '$lib';
 
     type $$Props = HTMLTextareaAttributes &
         Partial<{
@@ -53,12 +54,14 @@
             {...$$restProps}
             use:autofocusInput={autofocus}
         />
-        {#if maxlength}
-            <span class="limits">{value?.length ?? 0}/{maxlength}</span>
-        {/if}
-        {#if nullable}
-            <Nullable bind:disabled bind:value />
-        {/if}
+        <Layout.Stack direction="row" justifyContent="space-between">
+            {#if maxlength}
+                <span class="limits">{value?.length ?? 0}/{maxlength}</span>
+            {/if}
+            {#if nullable}
+                <Nullable bind:disabled bind:value />
+            {/if}
+        </Layout.Stack>
     </div>
 </Base>
 
@@ -70,6 +73,7 @@
 
         display: flex;
         flex-direction: column;
+        justify-content: space-between;
         gap: var(--space-5);
         width: 100%;
         border: var(--border-width-s) solid var(--border-neutral);


### PR DESCRIPTION
## What does this PR do?
The content stacking of the Textarea component got changed. The additional info (such as NULL and limit now) now sticks to the bottom of the Textarea (which you can see when resizing it). Also the stacking has changed. So before NULL and limit where side by side, they now spread out.

Before:
<img width="957" alt="image" src="https://github.com/user-attachments/assets/fc57a415-e058-456c-8f9e-7912d718923e" />

After:
<img width="951" alt="image" src="https://github.com/user-attachments/assets/97e99e0e-8f6c-4944-9eaf-8491c5f7a797" />


Another change is the animation on the height prop. There was a 0.15 animation length on this by default, which feel super laggy. Thats now removed.

Before:
https://github.com/user-attachments/assets/292ee8fd-e1b0-4fff-84be-637e6a4e21dd

After:
https://github.com/user-attachments/assets/d1595ba0-311c-41bd-b8da-83ed919ec3d0

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅