### PR TITLE
Fix the overflow of the tags

### DIFF
--- a/v2/pink-sb/src/lib/input/Tags.svelte
+++ b/v2/pink-sb/src/lib/input/Tags.svelte
@@ -123,7 +123,8 @@
 
     .input {
         @include transitions.common;
-
+        padding-block: var(--space-3);
+        flex-wrap: wrap;
         display: flex;
         gap: var(--space-5);
         align-items: center;
@@ -135,12 +136,9 @@
         outline-offset: calc(var(--border-width-s) * -1);
 
         input {
-            inline-size: 100%;
-            padding-block: var(--space-3);
             padding-inline: 0;
             border: none;
             display: block;
-            block-size: 2.5rem;
             background: none;
 
             &:disabled {


### PR DESCRIPTION
## What does this PR do?
Fix the overflow behaviour of the input tags component.

Before:

https://github.com/user-attachments/assets/9d267a00-47b8-4d68-bff7-aa29b6aa3d10


After:

https://github.com/user-attachments/assets/ce54ecaa-7b02-4460-88f5-8cbe35cefa7d


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅