### PR TITLE
Fix text input height

### DIFF
--- a/v2/pink-sb/src/lib/input/Textarea.svelte
+++ b/v2/pink-sb/src/lib/input/Textarea.svelte
@@ -110,6 +110,7 @@
 
         textarea {
             width: 100%;
+            height: 100%;
             &:disabled {
                 color: var(--fgcolor-neutral-tertiary);
             }


### PR DESCRIPTION
## What does this PR do?

Fixes an issue with the height/row of the textarea when the outer wrapper is longer in height.

## Test Plan

Manual.

Before -

<img width="1642" height="1212" alt="image" src="https://github.com/user-attachments/assets/a18d4eef-9aa8-4b54-9d51-6c460e9ef45b" />

After -

<img width="1336" height="641" alt="Screenshot 2025-07-18 at 3 30 15 PM" src="https://github.com/user-attachments/assets/a300710a-4825-41cc-a128-5c58db446ef1" />

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.