### PR TITLE
Fix: Fixes issue where long URLs, JSON strings, and other lengthy content

### DIFF
--- a/v2/pink-sb/src/lib/Logs.svelte
+++ b/v2/pink-sb/src/lib/Logs.svelte
@@ -286,20 +286,27 @@
             color: var(--fgcolor-neutral-primary);
             font-family: var(--font-family-code), var(--mono-fallbacks);
             font-size: var(--font-size-xs);
-            white-space: pre;
+            white-space: pre-wrap;
+            word-break: break-word;
+            overflow-wrap: break-word;
             line-height: 140%;
             letter-spacing: 0;
             max-height: 600px;
             width: 100%;
             overflow-y: scroll;
-            overflow-x: hidden;
+            overflow-x: auto;
             display: flex;
             flex-direction: column;
             padding: var(--space-6);
-            white-space: pre-line;
             scroll-behavior: smooth;
             height: var(--p-height);
             min-height: 10px;
+
+            code {
+                white-space: pre-wrap;
+                word-break: break-word;
+                overflow-wrap: break-word;
+            }
 
             &.full-height {
                 min-height: 300px;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes issue where long URLs, JSON strings, and other lengthy content
were being cut off instead of wrapping to the next line, making logs
unreadable in narrow containers.

## Test Plan
Before:
<img width="1518" height="744" alt="image" src="https://github.com/user-attachments/assets/7c281b7c-b619-4501-8868-a53801596aa5" />
After: 
<img width="1409" height="771" alt="image" src="https://github.com/user-attachments/assets/b1436549-830f-4f2b-8ac6-f3d3b3d115c7" />

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes