### PR TITLE
Change type names

### DIFF
--- a/v2/pink-sb/src/lib/spreadsheet/Cell.svelte
+++ b/v2/pink-sb/src/lib/spreadsheet/Cell.svelte
@@ -3,7 +3,7 @@
     import Skeleton from '$lib/Skeleton.svelte';
     import Textarea from '$lib/input/Textarea.svelte';
     import { clickOutside } from '$lib/helpers/helpers.js';
-    import { ESTIMATED_ROW_HEIGHT, EMPTY_ROW_ID, type Alignment, type RootProp } from './index.js';
+    import { ESTIMATED_ROW_HEIGHT, EMPTY_ROW_ID, type Alignment, type SpreadsheetRootProps } from './index.js';
     import {
         tick,
         onDestroy,
@@ -14,7 +14,7 @@
     } from 'svelte';
     import { getRowContext } from './context.js';
 
-    export let root: RootProp;
+    export let root: SpreadsheetRootProps;
     export let value: string | undefined = undefined;
     export let column: string | undefined = undefined;
     export let alignment: Alignment = 'middle-middle';

--- a/v2/pink-sb/src/lib/spreadsheet/Root.svelte
+++ b/v2/pink-sb/src/lib/spreadsheet/Root.svelte
@@ -8,7 +8,7 @@
     import { IconPlus } from '@appwrite.io/pink-icons-svelte';
     import { createVirtualizer } from '@tanstack/svelte-virtual';
     import { tick, onMount, createEventDispatcher, type ComponentProps } from 'svelte';
-    import { EMPTY_ROW_ID, ESTIMATED_ROW_HEIGHT, type Column, type RootProp } from './index.js';
+    import { EMPTY_ROW_ID, ESTIMATED_ROW_HEIGHT, type Column, type SpreadsheetRootProps } from './index.js';
 
     type TooltipPlacement = NonNullable<ComponentProps<Tooltip>['placement']>;
 
@@ -601,7 +601,7 @@
         expandKbdShortcut,
         currentFocusedRow,
         setFocusedRow
-    } as RootProp;
+    } as SpreadsheetRootProps;
 
     const virtualizer = createVirtualizer<HTMLDivElement, HTMLDivElement>({
         overscan: 5,

--- a/v2/pink-sb/src/lib/spreadsheet/index.ts
+++ b/v2/pink-sb/src/lib/spreadsheet/index.ts
@@ -31,7 +31,7 @@ export type Column = {
     isAction?: boolean;
 };
 
-export type RootProp = Readonly<{
+export type SpreadsheetRootProps = Readonly<{
     loading: boolean;
     selectedRows: string[];
     allowSelection: boolean;

--- a/v2/pink-sb/src/lib/spreadsheet/row/index.ts
+++ b/v2/pink-sb/src/lib/spreadsheet/row/index.ts
@@ -1,10 +1,10 @@
 import type { VirtualItem } from '@tanstack/svelte-virtual';
-import type { RootProp } from '../index.js';
+import type { SpreadsheetRootProps } from '../index.js';
 import Base from './Base.svelte';
 
 export type RowBaseProps = {
     id?: string;
-    root: RootProp;
+    root: SpreadsheetRootProps;
     virtualItem?: VirtualItem;
     index?: number;
     select?: true | 'disabled' | 'hidden';

--- a/v2/pink-sb/src/lib/table/cell/Base.svelte
+++ b/v2/pink-sb/src/lib/table/cell/Base.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-    import type { Alignment, RootProp } from '../index.js';
+    import type { Alignment, TableRootProps } from '../index.js';
 
     export let column: string | undefined = undefined;
-    export let root: RootProp;
+    export let root: TableRootProps;
     export let alignment: Alignment = 'middle-middle';
 
     $: options = column !== undefined && root.columnsMap?.[column];

--- a/v2/pink-sb/src/lib/table/cell/Virtual.svelte
+++ b/v2/pink-sb/src/lib/table/cell/Virtual.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import type { VirtualItem } from '@tanstack/svelte-virtual';
-    import type { Alignment, RootProp } from '../index.js';
+    import type { Alignment, TableRootProps } from '../index.js';
 
     export let column: string | undefined = undefined;
-    export let root: RootProp;
+    export let root: TableRootProps;
     export let virtualItem: VirtualItem;
     export let alignment: Alignment = 'middle-middle';
 

--- a/v2/pink-sb/src/lib/table/index.ts
+++ b/v2/pink-sb/src/lib/table/index.ts
@@ -19,7 +19,7 @@ export type Column = {
     hide?: boolean;
 };
 
-export type TableRootProps = {
+export type TableRootProps = Readonly<{
     allowSelection: boolean;
     selectedRows: string[];
     selectedAll: boolean;
@@ -31,7 +31,7 @@ export type TableRootProps = {
     toggleAll: () => void;
     addAvailableId: (id: string) => void;
     removeAvailableId: (id: string) => void;
-};
+}>;
 
 export type Alignment =
     | 'middle-middle'

--- a/v2/pink-sb/src/lib/table/index.ts
+++ b/v2/pink-sb/src/lib/table/index.ts
@@ -19,7 +19,7 @@ export type Column = {
     hide?: boolean;
 };
 
-export type RootProp = {
+export type TableRootProps = {
     allowSelection: boolean;
     selectedRows: string[];
     selectedAll: boolean;

--- a/v2/pink-sb/src/lib/table/root/Base.svelte
+++ b/v2/pink-sb/src/lib/table/root/Base.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { Column, RootProp } from '../index.js';
+    import type { Column, TableRootProps } from '../index.js';
 
     export let columns: Array<Column> | number;
     export let allowSelection: boolean = false;
@@ -44,7 +44,7 @@
         availableIds = availableIds;
     }
 
-    function groupById(cols: typeof columns): RootProp['columnsMap'] {
+    function groupById(cols: typeof columns): TableRootProps['columnsMap'] {
         if (typeof cols === 'number') {
             return {};
         }
@@ -66,7 +66,7 @@
         selectedAll: allRowsSelected,
         addAvailableId,
         removeAvailableId
-    } as RootProp;
+    } as TableRootProps;
 </script>
 
 <div class="root" bind:this={element}>

--- a/v2/pink-sb/src/lib/table/row/index.ts
+++ b/v2/pink-sb/src/lib/table/row/index.ts
@@ -1,4 +1,4 @@
-import type { RootProp } from '../index.js';
+import type { TableRootProps } from '../index.js';
 import Base from './Base.svelte';
 import Button from './Button.svelte';
 import Link from './Link.svelte';
@@ -6,7 +6,7 @@ import Link from './Link.svelte';
 export type RowBaseProps = {
     id?: string;
     select?: true | 'disabled' | 'hidden';
-    root: RootProp;
+    root: TableRootProps;
 };
 
 export default {


### PR DESCRIPTION
## What does this PR do?

Both Table and Spreadsheet had their root prop type named as `RootProp` which caused wrong import issues on Console.

## Test Plan

N/A.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.