### PR TITLE
Fix: number input bigint and cleanup

### DIFF
--- a/v2/pink-sb/src/lib/input/Number.svelte
+++ b/v2/pink-sb/src/lib/input/Number.svelte
@@ -44,12 +44,15 @@
     let bigintMode = false;
     let minAttr: NativeNumber = undefined;
     let maxAttr: NativeNumber = undefined;
+    let inputValue = '';
 
     let input: HTMLInputElement;
     const dispatch = createEventDispatcher();
 
-    $: if (typeof value === 'bigint' || typeof value === 'number') {
-        bigintMode = typeof value === 'bigint';
+    $: bigintMode = typeof value === 'bigint';
+
+    function valueToDisplayString(v: ExtendedNumber): string {
+        return v === null || v === undefined ? '' : v.toString();
     }
 
     function toNumberInputBound(raw: ExtendedNumber): NativeNumber {
@@ -80,65 +83,63 @@
     $: maxAttr = bigintMode ? undefined : toNumberInputBound(max);
 
     function fireOnChangeDispatch(next: ExtendedNumber) {
-        let current = next;
-
         if (bigintMode) {
-            const parsed = parseBigIntValue(current);
-            value = parsed ?? current;
+            const parsed = parseBigIntValue(next);
+            value = parsed ?? value;
+            inputValue = valueToDisplayString(value);
             dispatch('change', parsed ?? undefined);
             return;
         }
-        const num = Number(current);
-        value = Number.isNaN(num) ? current : num;
+        const num = Number(next);
+        value = Number.isNaN(num) ? next : num;
         dispatch('change', Number.isNaN(num) ? undefined : num);
+    }
+
+    function clampBigInt(val: bigint, minVal: bigint | null, maxVal: bigint | null): bigint {
+        let result = val;
+        if (minVal !== null && result < minVal) result = minVal;
+        if (maxVal !== null && result > maxVal) result = maxVal;
+        return result;
+    }
+
+    function stepBigInt(direction: 1 | -1): void {
+        const stepValue = parseBigIntStep(step);
+        const current = parseBigIntValue(value) ?? 0n;
+        const bounds = { min: parseBigIntBound(min), max: parseBigIntBound(max) };
+        const next = clampBigInt(
+            current + (direction === 1 ? stepValue : -stepValue),
+            bounds.min,
+            bounds.max
+        );
+        fireOnChangeDispatch(next);
     }
 
     function increment(): void {
         if (bigintMode) {
-            const stepValue = parseBigIntStep(step);
-            const current = parseBigIntValue(value) ?? 0n;
-            const minValue = parseBigIntBound(min);
-            const maxValue = parseBigIntBound(max);
-            let next = current + stepValue;
-
-            if (minValue !== null && next < minValue) {
-                next = minValue;
-            }
-
-            if (maxValue !== null && next > maxValue) {
-                next = maxValue;
-            }
-
-            fireOnChangeDispatch(next);
+            stepBigInt(1);
             return;
         }
-
         input.stepUp();
         fireOnChangeDispatch(input.value);
     }
 
     function decrement(): void {
         if (bigintMode) {
-            const stepValue = parseBigIntStep(step);
-            const current = parseBigIntValue(value) ?? 0n;
-            const minValue = parseBigIntBound(min);
-            const maxValue = parseBigIntBound(max);
-            let next = current - stepValue;
-
-            if (minValue !== null && next < minValue) {
-                next = minValue;
-            }
-
-            if (maxValue !== null && next > maxValue) {
-                next = maxValue;
-            }
-
-            fireOnChangeDispatch(next);
+            stepBigInt(-1);
             return;
         }
-
         input.stepDown();
         fireOnChangeDispatch(input.value);
+    }
+
+    function handleBigIntInput(e: Event & { currentTarget: EventTarget & HTMLInputElement }) {
+        const raw = e.currentTarget.value;
+        fireOnChangeDispatch(raw);
+        inputValue = raw;
+    }
+
+    $: if (bigintMode) {
+        inputValue = valueToDisplayString(value);
     }
 </script>
 
@@ -161,7 +162,8 @@
                     on:invalid
                     on:change={fireOnChangeDispatch}
                     bind:this={input}
-                    bind:value
+                    value={inputValue}
+                    on:input={handleBigIntInput}
                     type="text"
                     inputmode="numeric"
                     {disabled}
@@ -206,7 +208,7 @@
             <button
                 disabled={disabled || readonly}
                 on:mousedown={decrement}
-                on:keydown={increment}
+                on:keydown={decrement}
                 tabindex="-1"
                 type="button"
             >


### PR DESCRIPTION
…reduce duplication

- Use inputValue buffer in bigint mode so value stays bigint (fixes type flip to number)
- Fix decrement button on:keydown to call decrement instead of increment
- Add valueToDisplayString() and stepBigInt(direction) to remove repeated logic
- Simplify fireOnChangeDispatch reactive sync (no lastDispatchedBigInt tracking)

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)