### PR TITLE
feat: add progress bar support to Upload.Box

### DIFF
--- a/v2/pink-sb/src/lib/upload/Box.svelte
+++ b/v2/pink-sb/src/lib/upload/Box.svelte
@@ -114,11 +114,8 @@
                                             />
                                         </Stack>
                                     {:else if hasProgress}
-                                        <Text
-                                            color="--fgcolor-neutral-tertiary"
-                                            variant="m-400"
-                                        >
-                                            {file.progress}%
+                                        <Text color="--fgcolor-neutral-tertiary" variant="m-400">
+                                            {Math.min(Math.max(file.progress ?? 0, 0), 100)}%
                                         </Text>
                                     {:else if file?.status === 'pending'}
                                         <Stack inline justifyContent="center">
@@ -150,7 +147,7 @@
                         {#if hasProgress && file?.status !== 'success'}
                             <div
                                 class="upload-progress-bar"
-                                class:is-error={file?.status === 'failed'}
+                                class:is-error={!!file?.error || file?.status === 'failed'}
                             >
                                 <div
                                     class="upload-progress-bar-fill"
@@ -204,7 +201,7 @@
         &-fill {
             height: 100%;
             border-radius: inherit;
-            background: var(--bgcolor-information, hsl(220 80% 55%));
+            background: var(--bgcolor-accent);
             transition: width 0.3s ease;
         }
 

--- a/v2/pink-sb/src/lib/upload/Box.svelte
+++ b/v2/pink-sb/src/lib/upload/Box.svelte
@@ -22,6 +22,7 @@
         size?: number;
         extension?: string;
         error?: string;
+        progress?: number;
         status?: 'failed' | 'pending' | 'success';
     })[] = [];
 
@@ -67,75 +68,96 @@
         <div transition:slide={{ axis: 'y', duration: 200 }}>
             {#each files as file}
                 {@const fileSize = file?.size ? humanFileSize(file.size) : false}
+                {@const hasProgress = typeof file?.progress === 'number'}
                 <section>
-                    <Stack
-                        direction="row"
-                        gap="s"
-                        justifyContent="space-between"
-                        alignItems="center"
-                    >
-                        <Stack direction="row" gap="s" style="overflow: hidden;">
-                            <Icon
-                                icon={IconDocument}
-                                color={file?.error
-                                    ? '--fgcolor-error'
-                                    : '--fgcolor-neutral-tertiary'}
-                            />
-                            <Stack direction="row" gap="xxs" inline style="min-width: 0;">
-                                <Text truncate>
-                                    {file.name}
-                                </Text>
-                                {#if fileSize}
-                                    <Text color="--fgcolor-neutral-tertiary">
-                                        <span style="white-space: nowrap">
-                                            ({fileSize.value}
-                                            {fileSize.unit})
-                                        </span>
+                    <Stack direction="column" gap="xs">
+                        <Stack
+                            direction="row"
+                            gap="s"
+                            justifyContent="space-between"
+                            alignItems="center"
+                        >
+                            <Stack direction="row" gap="s" style="overflow: hidden;">
+                                <Icon
+                                    icon={IconDocument}
+                                    color={file?.error
+                                        ? '--fgcolor-error'
+                                        : '--fgcolor-neutral-tertiary'}
+                                />
+                                <Stack direction="row" gap="xxs" inline style="min-width: 0;">
+                                    <Text truncate>
+                                        {file.name}
                                     </Text>
+                                    {#if fileSize}
+                                        <Text color="--fgcolor-neutral-tertiary">
+                                            <span style="white-space: nowrap">
+                                                ({fileSize.value}
+                                                {fileSize.unit})
+                                            </span>
+                                        </Text>
+                                    {/if}
+                                </Stack>
+                            </Stack>
+                            <Stack direction="row" gap="xxs" inline>
+                                {#if file?.status === 'success'}
+                                    <Button variant="text" icon size="s">
+                                        <Icon icon={IconCheck} color="--fgcolor-success" size="s" />
+                                    </Button>
+                                {:else}
+                                    {#if file?.error}
+                                        <Stack inline justifyContent="center">
+                                            <Badge
+                                                variant="secondary"
+                                                type="error"
+                                                content="Failed"
+                                                size="s"
+                                            />
+                                        </Stack>
+                                    {:else if hasProgress}
+                                        <Text
+                                            color="--fgcolor-neutral-tertiary"
+                                            variant="m-400"
+                                        >
+                                            {file.progress}%
+                                        </Text>
+                                    {:else if file?.status === 'pending'}
+                                        <Stack inline justifyContent="center">
+                                            <Badge
+                                                variant="secondary"
+                                                type="warning"
+                                                content="Pending"
+                                                size="s"
+                                            />
+                                        </Stack>
+                                    {/if}
+                                    <Button
+                                        variant="text"
+                                        icon
+                                        size="s"
+                                        on:click={() => {
+                                            dispatch('remove', file);
+                                        }}
+                                    >
+                                        <Icon
+                                            icon={IconX}
+                                            color="--fgcolor-neutral-tertiary"
+                                            size="s"
+                                        />
+                                    </Button>
                                 {/if}
                             </Stack>
                         </Stack>
-                        <Stack direction="row" gap="xxs" inline>
-                            {#if file?.status === 'success'}
-                                <Button variant="text" icon size="s">
-                                    <Icon icon={IconCheck} color="--fgcolor-success" size="s" />
-                                </Button>
-                            {:else}
-                                {#if file?.error}
-                                    <Stack inline justifyContent="center">
-                                        <Badge
-                                            variant="secondary"
-                                            type="error"
-                                            content="Failed"
-                                            size="s"
-                                        />
-                                    </Stack>
-                                {:else if file?.status === 'pending'}
-                                    <Stack inline justifyContent="center">
-                                        <Badge
-                                            variant="secondary"
-                                            type="warning"
-                                            content="Pending"
-                                            size="s"
-                                        />
-                                    </Stack>
-                                {/if}
-                                <Button
-                                    variant="text"
-                                    icon
-                                    size="s"
-                                    on:click={() => {
-                                        dispatch('remove', file);
-                                    }}
-                                >
-                                    <Icon
-                                        icon={IconX}
-                                        color="--fgcolor-neutral-tertiary"
-                                        size="s"
-                                    />
-                                </Button>
-                            {/if}
-                        </Stack>
+                        {#if hasProgress && file?.status !== 'success'}
+                            <div
+                                class="upload-progress-bar"
+                                class:is-error={file?.status === 'failed'}
+                            >
+                                <div
+                                    class="upload-progress-bar-fill"
+                                    style="width: {Math.min(Math.max(file.progress ?? 0, 0), 100)}%"
+                                />
+                            </div>
+                        {/if}
                     </Stack>
                 </section>
             {/each}
@@ -169,6 +191,25 @@
             background: var(--bgcolor-neutral-default);
             border-top: var(--border-width-s) solid var(--border-neutral);
             flex-shrink: 1;
+        }
+    }
+
+    .upload-progress-bar {
+        height: 4px;
+        width: 100%;
+        border-radius: var(--border-radius-XS, 4px);
+        background: var(--bgcolor-neutral-secondary, hsl(0 0% 90%));
+        overflow: hidden;
+
+        &-fill {
+            height: 100%;
+            border-radius: inherit;
+            background: var(--bgcolor-information, hsl(220 80% 55%));
+            transition: width 0.3s ease;
+        }
+
+        &.is-error &-fill {
+            background: var(--bgcolor-error, hsl(0 70% 55%));
         }
     }
 </style>

--- a/v2/pink-sb/src/lib/upload/Box.svelte
+++ b/v2/pink-sb/src/lib/upload/Box.svelte
@@ -68,7 +68,11 @@
         <div transition:slide={{ axis: 'y', duration: 200 }}>
             {#each files as file}
                 {@const fileSize = file?.size ? humanFileSize(file.size) : false}
-                {@const hasProgress = typeof file?.progress === 'number'}
+                {@const hasProgress = typeof file?.progress === 'number' && file.progress > 0}
+                {@const clampedProgress = hasProgress
+                    ? Math.round(Math.min(Math.max(file.progress ?? 0, 0), 100))
+                    : 0}
+                {@const isError = !!file?.error || file?.status === 'failed'}
                 <section>
                     <Stack direction="column" gap="xs">
                         <Stack
@@ -100,11 +104,9 @@
                             </Stack>
                             <Stack direction="row" gap="xxs" inline>
                                 {#if file?.status === 'success'}
-                                    <Button variant="text" icon size="s">
-                                        <Icon icon={IconCheck} color="--fgcolor-success" size="s" />
-                                    </Button>
+                                    <Icon icon={IconCheck} color="--fgcolor-success" size="s" />
                                 {:else}
-                                    {#if file?.error}
+                                    {#if isError}
                                         <Stack inline justifyContent="center">
                                             <Badge
                                                 variant="secondary"
@@ -114,8 +116,8 @@
                                             />
                                         </Stack>
                                     {:else if hasProgress}
-                                        <Text color="--fgcolor-neutral-tertiary" variant="m-400">
-                                            {Math.min(Math.max(file.progress ?? 0, 0), 100)}%
+                                        <Text color="--fgcolor-neutral-tertiary">
+                                            {clampedProgress}%
                                         </Text>
                                     {:else if file?.status === 'pending'}
                                         <Stack inline justifyContent="center">
@@ -147,11 +149,16 @@
                         {#if hasProgress && file?.status !== 'success'}
                             <div
                                 class="upload-progress-bar"
-                                class:is-error={!!file?.error || file?.status === 'failed'}
+                                class:is-error={isError}
+                                role="progressbar"
+                                aria-valuenow={clampedProgress}
+                                aria-valuemin={0}
+                                aria-valuemax={100}
+                                aria-label="{file.name} upload progress"
                             >
                                 <div
                                     class="upload-progress-bar-fill"
-                                    style="width: {Math.min(Math.max(file.progress ?? 0, 0), 100)}%"
+                                    style="width: {clampedProgress}%"
                                 />
                             </div>
                         {/if}

--- a/v2/pink-sb/src/stories/upload/Box.stories.svelte
+++ b/v2/pink-sb/src/stories/upload/Box.stories.svelte
@@ -28,6 +28,38 @@
             status: 'pending'
         }
     ];
+
+    let filesWithProgress = [
+        {
+            name: 'uploading-file.png',
+            extension: 'png',
+            size: 15728640,
+            status: 'pending',
+            progress: 45
+        },
+        {
+            name: 'almost-done.pdf',
+            extension: 'pdf',
+            size: 8388608,
+            status: 'pending',
+            progress: 92
+        },
+        {
+            name: 'completed-file.jpg',
+            extension: 'jpg',
+            size: 41024,
+            status: 'success',
+            progress: 100
+        },
+        {
+            name: 'failed-upload.zip',
+            extension: 'zip',
+            size: 52428800,
+            status: 'failed',
+            error: 'File exceeds size limit',
+            progress: 60
+        }
+    ];
 </script>
 
 <script>
@@ -42,5 +74,12 @@
     name="Default"
     args={{
         files
+    }}
+/>
+
+<Story
+    name="With Progress"
+    args={{
+        files: filesWithProgress
     }}
 />


### PR DESCRIPTION
## Summary
- Adds optional `progress?: number` prop to `Upload.Box` file items
- Renders an animated 4px progress bar below each file row when `progress` is provided
- Shows percentage text (e.g. "45%") instead of "Pending" badge during upload
- Error state turns the progress bar red via `is-error` styling
- Fully backwards compatible — omitting `progress` preserves existing behavior
- Adds "With Progress" Storybook story covering uploading, near-complete, completed, and failed states

